### PR TITLE
Fix compiling 'pngtopng' at top of example.c

### DIFF
--- a/example.c
+++ b/example.c
@@ -125,6 +125,7 @@ int main(int argc, const char **argv)
                png_image_free(&image);
             else
                free(buffer);
+         }
       }
 
       /* Something went wrong reading or writing the image.  libpng stores a


### PR DESCRIPTION
Compiling `pngtopng` at top of example.c fails due to missing brace. I tested after adding brace and it works.